### PR TITLE
Add Auden probe configuration templates

### DIFF
--- a/configs/probe.Auden.Chords1217.yaml
+++ b/configs/probe.Auden.Chords1217.yaml
@@ -1,0 +1,145 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [1]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.Chords1217.Auden/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/acc"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.Chords1217.Auden"
+      save_dir: "./output/probe.Chords1217.Auden/"
+
+
+model:
+  class_path: marble.tasks.Chords1217.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Auden.model.Auden_Encoder
+      init_args:
+        pre_trained_folder: null
+        train_mode: freeze
+    emb_transforms:
+      - class_path: marble.modules.transforms.LayerSelector
+        init_args:
+          layers: [15]
+      - class_path: marble.modules.transforms.TimeAvgPool
+    
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoderKeepTime
+        init_args:
+          in_dim: 512
+          out_dim: 25 # 10 genres
+          hidden_layers: [512]
+          activation_fn: 
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: marble.tasks.Chords1217.probe.ChordCrossEntropyLoss 
+        init_args:
+          time_dim_mismatch_tol: 5
+
+    metrics:
+      train:
+        acc:
+          class_path: marble.tasks.Chords1217.probe.ChordAccuracy
+          init_args:
+            time_dim_mismatch_tol: 5
+            ignore_index: -1 # ignore the non maj min chords
+
+      val:
+        acc:
+          class_path: marble.tasks.Chords1217.probe.ChordAccuracy
+          init_args:
+            time_dim_mismatch_tol: 5
+            ignore_index: -1 # ignore the non maj min chords
+
+      test:
+        acc:
+          class_path: marble.tasks.Chords1217.probe.ChordAccuracy
+          init_args:
+            time_dim_mismatch_tol: 5
+            ignore_index: -1 # ignore the non maj min chords
+    
+data:
+  class_path: marble.tasks.Chords1217.datamodule.Chords1217DataModule
+  init_args:
+    batch_size: 8
+    num_workers: 16
+
+    train:
+      class_path: marble.tasks.Chords1217.datamodule.Chords1217AudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1 # at least 10% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/Chords1217/Chords1217.train.jsonl
+        label_freq: 50
+        backend: "soundfile" # speed up random read flac
+    val:
+      class_path: marble.tasks.Chords1217.datamodule.Chords1217AudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/Chords1217/Chords1217.val.jsonl
+        label_freq: 50
+        backend: "soundfile" # speed up random read flac
+    test:
+      class_path: marble.tasks.Chords1217.datamodule.Chords1217AudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/Chords1217/Chords1217.test.jsonl
+        label_freq: 50
+        backend: "soundfile" # speed up random read flac
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/acc"

--- a/configs/probe.Auden.EMO.yaml
+++ b/configs/probe.Auden.EMO.yaml
@@ -1,0 +1,159 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 100
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.EMO.Auden/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/r2"               # 要监控的 metric 名称
+        patience: 20                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.EMO.Auden"
+      save_dir: "./output/probe.EMO.Auden/"
+
+
+model:
+  class_path: marble.tasks.EMO.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Auden.model.Auden_Encoder
+      init_args:
+        pre_trained_folder: null
+        train_mode: freeze
+    emb_transforms:
+      - class_path: marble.modules.transforms.LayerSelector
+        init_args:
+          layers: [15]
+      - class_path: marble.modules.transforms.TimeAvgPool
+    
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 512
+          out_dim: 2 # 2 genres
+          hidden_layers: [512]
+          activation_fn: 
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      # regression
+      - class_path: torch.nn.MSELoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        r2:
+          class_path: torchmetrics.R2Score
+          init_args:
+            multioutput: uniform_average
+        arousal_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 0
+        valence_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 1
+      val:
+        r2:
+          class_path: torchmetrics.R2Score
+          init_args:
+            multioutput: uniform_average
+        arousal_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 0
+        valence_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 1
+      test:
+        r2:
+          class_path: torchmetrics.R2Score
+          init_args:
+            multioutput: uniform_average
+        arousal_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 0
+        valence_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 1
+    
+data:
+  class_path: marble.tasks.EMO.datamodule.EMODataModule
+  init_args:
+    batch_size: 16
+    num_workers: 8
+
+    train:
+      class_path: marble.tasks.EMO.datamodule.EMOAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/EMO/EMO.train.jsonl
+    val:
+      class_path: marble.tasks.EMO.datamodule.EMOAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/EMO/EMO.val.jsonl
+    test:
+      class_path: marble.tasks.EMO.datamodule.EMOAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/EMO/EMO.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 6
+    monitor: "val/r2"

--- a/configs/probe.Auden.GS.yaml
+++ b/configs/probe.Auden.GS.yaml
@@ -1,0 +1,143 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.GS.Auden/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/weighted_score"               # 要监控的 metric 名称
+        patience: 20                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.GS.Auden"
+      save_dir: "./output/probe.GS.Auden/"
+
+
+model:
+  class_path: marble.tasks.GS.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Auden.model.Auden_Encoder
+      init_args:
+        pre_trained_folder: null
+        train_mode: freeze
+    emb_transforms:
+      - class_path: marble.modules.transforms.LayerSelector
+        init_args:
+          layers: [15]
+      - class_path: marble.modules.transforms.TimeAvgPool
+    
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 512
+          out_dim: 24 # 24 KEYS
+          hidden_layers: [512]
+          activation_fn: 
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.GS.probe.KeyWeightedScore
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.GS.probe.KeyWeightedScore
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.GS.probe.KeyWeightedScore
+    
+data:
+  class_path: marble.tasks.GS.datamodule.GSDataModule
+  init_args:
+    batch_size: 16
+    num_workers: 8
+
+    train:
+      class_path: marble.tasks.GS.datamodule.GSAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/GS/GS.train.jsonl
+    val:
+      class_path: marble.tasks.GS.datamodule.GSAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GS/GS.val.jsonl
+    test:
+      class_path: marble.tasks.GS.datamodule.GSAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GS/GS.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/weighted_score"

--- a/configs/probe.Auden.GTZANBeatTracking.yaml
+++ b/configs/probe.Auden.GTZANBeatTracking.yaml
@@ -1,0 +1,185 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.GTZANBeatTracking.Auden/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/beat_f1"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.GTZANBeatTracking.Auden"
+      save_dir: "./output/probe.GTZANBeatTracking.Auden/"
+
+
+model:
+  class_path: marble.tasks.GTZANBeatTracking.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    fps: 50
+    use_ema: false
+    loss_weights: [1.0, 1.0, 0.0] # beat, downbeat, tempo (tempo disabled, seems interfering with beat tracking)
+
+    encoder:
+      class_path: marble.encoders.Auden.model.Auden_Encoder
+      init_args:
+        pre_trained_folder: null
+        train_mode: freeze
+    emb_transforms:
+      - class_path: marble.modules.transforms.LayerSelector
+        init_args:
+          layers: [15]
+      - class_path: marble.modules.transforms.TimeAvgPool
+    
+    decoders:
+      - class_path: marble.tasks.GTZANBeatTracking.probe.BeatDownbeatTempoMultitaskDecoder
+        init_args:
+          fps: 50
+          use_ssl_for_tempo: false
+          
+          joint_decoder:
+            class_path: marble.modules.decoders.MLPDecoderKeepTime
+            init_args:
+              in_dim: 512
+              out_dim: 3 # beat, downbeat, tempo
+              hidden_layers: [512]
+              activation_fn: 
+                class_path: torch.nn.ReLU
+              dropout: 0.2
+
+          tempo_decoder:
+            class_path: marble.tasks.GTZANBeatTracking.modules.FFTTempoEstimator
+            init_args:
+              label_fps: 50
+              freq_resolution: 4
+
+    losses:
+      - class_path: marble.tasks.GTZANBeatTracking.probe.CustomBCEWithLogitsLoss # beat 
+        init_args:
+          pos_weight: null 
+          time_dim_mismatch_tol: 5
+      - class_path: marble.tasks.GTZANBeatTracking.probe.CustomBCEWithLogitsLoss # downbeat
+        init_args:
+          pos_weight: null 
+          time_dim_mismatch_tol: 5
+      - class_path: torch.nn.MSELoss # tempo
+        init_args:
+          reduction: mean
+
+    metrics:
+      val:
+        beat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 50
+            tol: 0.07
+            threshold: 0.99
+        downbeat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 50
+            tol: 0.07
+            threshold: 0.99
+        tempo_mae:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoMAE
+        tempo_acc:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoAccuracy
+          init_args:
+            tol: 0.04
+      test:
+        beat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 50
+            tol: 0.07
+            threshold: 0.99
+        downbeat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 50
+            tol: 0.07
+            threshold: 0.99
+        tempo_mae:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoMAE
+        tempo_acc:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoAccuracy
+          init_args:
+            tol: 0.04
+    
+data:
+  class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingDataModule
+  init_args:
+    batch_size: 8
+    num_workers: 8
+
+    train:
+      class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 10
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/GTZAN/GTZANBeatTracking.train.jsonl
+        label_freq: 50
+        num_neighbors: 2
+    val:
+      class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 10
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANBeatTracking.val.jsonl
+        label_freq: 50
+        num_neighbors: 0
+    test:
+      class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 10
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANBeatTracking.test.jsonl
+        label_freq: 50
+        num_neighbors: 0
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/beat_f1"

--- a/configs/probe.Auden.GTZANGenre.yaml
+++ b/configs/probe.Auden.GTZANGenre.yaml
@@ -1,0 +1,137 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.GTZANGenre.Auden/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/acc"               # 要监控的 metric 名称
+        patience: 20                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.GTZANGenre.Auden"
+      save_dir: "./output/probe.GTZANGenre.Auden/"
+
+
+model:
+  class_path: marble.tasks.GTZANGenre.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Auden.model.Auden_Encoder
+      init_args:
+        pre_trained_folder: null
+        train_mode: freeze
+    emb_transforms:
+      - class_path: marble.modules.transforms.LayerSelector
+        init_args:
+          layers: [15]
+      - class_path: marble.modules.transforms.TimeAvgPool
+    
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 512
+          out_dim: 10 # 10 genres
+          hidden_layers: [512]
+          activation_fn: 
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 10
+            task: multiclass
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 10
+            task: multiclass
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 10
+            task: multiclass
+    
+data:
+  class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreDataModule
+  init_args:
+    batch_size: 8
+    num_workers: 8
+
+    train:
+      class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30.2
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/GTZAN/GTZANGenre.train.jsonl
+    val:
+      class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30.2
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANGenre.val.jsonl
+    test:
+      class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30.2
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANGenre.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 5e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 6
+    monitor: "val/acc"

--- a/configs/probe.Auden.HookTheoryKey.yaml
+++ b/configs/probe.Auden.HookTheoryKey.yaml
@@ -1,0 +1,143 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [1]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.HookTheoryKey.Auden/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/weighted_score"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.HookTheoryKey.Auden"
+      save_dir: "./output/probe.HookTheoryKey.Auden/"
+
+
+model:
+  class_path: marble.tasks.HookTheoryKey.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Auden.model.Auden_Encoder
+      init_args:
+        pre_trained_folder: null
+        train_mode: freeze
+    emb_transforms:
+      - class_path: marble.modules.transforms.LayerSelector
+        init_args:
+          layers: [15]
+      - class_path: marble.modules.transforms.TimeAvgPool
+    
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 512
+          out_dim: 24 # 24 KEYS
+          hidden_layers: [512]
+          activation_fn: 
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+    
+data:
+  class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyDataModule
+  init_args:
+    batch_size: 16
+    num_workers: 8
+
+    train:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/HookTheory/HookTheoryKey.train.jsonl
+    val:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/HookTheory/HookTheoryKey.val.jsonl
+    test:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/HookTheory/HookTheoryKey.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/weighted_score"

--- a/configs/probe.Auden.HookTheoryStructure.yaml
+++ b/configs/probe.Auden.HookTheoryStructure.yaml
@@ -1,0 +1,137 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.HookTheoryStructure.Auden/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/acc"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.HookTheoryStructure.Auden"
+      save_dir: "./output/probe.HookTheoryStructure.Auden/"
+
+
+model:
+  class_path: marble.tasks.HookTheoryStructure.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Auden.model.Auden_Encoder
+      init_args:
+        pre_trained_folder: null
+        train_mode: freeze
+    emb_transforms:
+      - class_path: marble.modules.transforms.LayerSelector
+        init_args:
+          layers: [15]
+      - class_path: marble.modules.transforms.TimeAvgPool
+    
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 512
+          out_dim: 7 # 7 structure classes
+          hidden_layers: [512]
+          activation_fn: 
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 7
+            task: multiclass
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 7
+            task: multiclass
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 7
+            task: multiclass
+    
+data:
+  class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureDataModule
+  init_args:
+    batch_size: 16
+    num_workers: 16
+
+    train:
+      class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1 # at least 80% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/HookTheory/HookTheoryStructure.train.jsonl
+    val:
+      class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryStructure.val.jsonl
+    test:
+      class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryStructure.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/acc"

--- a/configs/probe.Auden.MTGGenre.yaml
+++ b/configs/probe.Auden.MTGGenre.yaml
@@ -1,0 +1,185 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  strategy: ddp # or ddp_find_unused_parameters 
+  devices: [4,5,6,7] # torchrun --nproc_per_node=4 cli.py fit -c xxx
+  # devices: [0,]
+  accumulate_grad_batches: 1
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGGenre.Auden/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGGenre.Auden"
+      save_dir: "./output/probe.MTGGenre.Auden/"
+
+
+model:
+  class_path: marble.tasks.MTGGenre.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Auden.model.Auden_Encoder
+      init_args:
+        pre_trained_folder: null
+        train_mode: freeze
+    emb_transforms:
+      - class_path: marble.modules.transforms.LayerSelector
+        init_args:
+          layers: [15]
+      - class_path: marble.modules.transforms.TimeAvgPool
+    
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 512
+          out_dim: 87
+          hidden_layers: [512]
+          activation_fn: 
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro # Can be 'micro', 'macro', or 'weighted'
+        f1_micro:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: micro # Can be 'micro', 'macro', or 'weighted'
+      val:
+        f1:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro # Can be 'micro', 'macro', or 'weighted'
+        auroc:
+          class_path: torchmetrics.AUROC # ADD
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision # ADD
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: micro # Can be 'micro', 'macro', or 'weighted'
+      test:
+        f1:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro # Can be 'micro', 'macro', or 'weighted'
+        f1_micro:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: micro # Can be 'micro', 'macro', or 'weighted'
+        auroc:
+          class_path: torchmetrics.AUROC # ADD
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision # ADD
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+    
+data:
+  class_path: marble.tasks.MTGGenre.datamodule.MTGGenreDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 32
+
+    train:
+      class_path: marble.tasks.MTGGenre.datamodule.MTGGenreAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGGenre.train.jsonl
+    val:
+      class_path: marble.tasks.MTGGenre.datamodule.MTGGenreAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGGenre.val.jsonl
+    test:
+      class_path: marble.tasks.MTGGenre.datamodule.MTGGenreAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGGenre.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 3
+    monitor: "val/auroc"

--- a/configs/probe.Auden.MTGInstrument.yaml
+++ b/configs/probe.Auden.MTGInstrument.yaml
@@ -1,0 +1,184 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  strategy: ddp # or ddp_find_unused_parameters 
+  devices: [4,5,6,7] # torchrun --nproc_per_node=4 cli.py fit -c xxx
+  accumulate_grad_batches: 1
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGInstrument.Auden/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGInstrument.Auden"
+      save_dir: "./output/probe.MTGInstrument.Auden/"
+
+
+model:
+  class_path: marble.tasks.MTGInstrument.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Auden.model.Auden_Encoder
+      init_args:
+        pre_trained_folder: null
+        train_mode: freeze
+    emb_transforms:
+      - class_path: marble.modules.transforms.LayerSelector
+        init_args:
+          layers: [15]
+      - class_path: marble.modules.transforms.TimeAvgPool
+    
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 512
+          out_dim: 40
+          hidden_layers: [512]
+          activation_fn: 
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro # Can be 'micro', 'macro', or 'weighted'
+        f1_micro:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: micro # Can be 'micro', 'macro', or 'weighted'
+      val:
+        f1:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro # Can be 'micro', 'macro', or 'weighted'
+        auroc:
+          class_path: torchmetrics.AUROC # ADD
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision # ADD
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: micro # Can be 'micro', 'macro', or 'weighted'
+      test:
+        f1:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro # Can be 'micro', 'macro', or 'weighted'
+        f1_micro:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: micro # Can be 'micro', 'macro', or 'weighted'
+        auroc:
+          class_path: torchmetrics.AUROC # ADD
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision # ADD
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+    
+data:
+  class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 32
+
+    train:
+      class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGInstrument.train.jsonl
+    val:
+      class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGInstrument.val.jsonl
+    test:
+      class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGInstrument.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 3
+    monitor: "val/auroc"

--- a/configs/probe.Auden.MTGMood.yaml
+++ b/configs/probe.Auden.MTGMood.yaml
@@ -1,0 +1,184 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  strategy: ddp # or ddp_find_unused_parameters 
+  devices: [4,5,6,7] # torchrun --nproc_per_node=4 cli.py fit -c xxx
+  accumulate_grad_batches: 1
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGMood.Auden/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGMood.Auden"
+      save_dir: "./output/probe.MTGMood.Auden/"
+
+
+model:
+  class_path: marble.tasks.MTGMood.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Auden.model.Auden_Encoder
+      init_args:
+        pre_trained_folder: null
+        train_mode: freeze
+    emb_transforms:
+      - class_path: marble.modules.transforms.LayerSelector
+        init_args:
+          layers: [15]
+      - class_path: marble.modules.transforms.TimeAvgPool
+    
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 512
+          out_dim: 56 # 10 genres
+          hidden_layers: [512]
+          activation_fn: 
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro # Can be 'micro', 'macro', or 'weighted'
+        f1_micro:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: micro # Can be 'micro', 'macro', or 'weighted'
+      val:
+        f1:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro # Can be 'micro', 'macro', or 'weighted'
+        auroc:
+          class_path: torchmetrics.AUROC # ADD
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision # ADD
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: micro # Can be 'micro', 'macro', or 'weighted'
+      test:
+        f1:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro # Can be 'micro', 'macro', or 'weighted'
+        f1_micro:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: micro # Can be 'micro', 'macro', or 'weighted'
+        auroc:
+          class_path: torchmetrics.AUROC # ADD
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision # ADD
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+    
+data:
+  class_path: marble.tasks.MTGMood.datamodule.MTGMoodDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 32
+
+    train:
+      class_path: marble.tasks.MTGMood.datamodule.MTGMoodAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGMood.train.jsonl
+    val:
+      class_path: marble.tasks.MTGMood.datamodule.MTGMoodAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGMood.val.jsonl
+    test:
+      class_path: marble.tasks.MTGMood.datamodule.MTGMoodAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGMood.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 3
+    monitor: "val/auroc"

--- a/configs/probe.Auden.MTGTop50.yaml
+++ b/configs/probe.Auden.MTGTop50.yaml
@@ -1,0 +1,184 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  strategy: ddp # or ddp_find_unused_parameters 
+  devices: [4,5,6,7] # torchrun --nproc_per_node=4 cli.py fit -c xxx
+  accumulate_grad_batches: 1
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGTop50.Auden/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGTop50.Auden"
+      save_dir: "./output/probe.MTGTop50.Auden/"
+
+
+model:
+  class_path: marble.tasks.MTGTop50.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Auden.model.Auden_Encoder
+      init_args:
+        pre_trained_folder: null
+        train_mode: freeze
+    emb_transforms:
+      - class_path: marble.modules.transforms.LayerSelector
+        init_args:
+          layers: [15]
+      - class_path: marble.modules.transforms.TimeAvgPool
+    
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 512
+          out_dim: 50 # 10 genres
+          hidden_layers: [512]
+          activation_fn: 
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro # Can be 'micro', 'macro', or 'weighted'
+        f1_micro:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro # Can be 'micro', 'macro', or 'weighted'
+      val:
+        f1:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro # Can be 'micro', 'macro', or 'weighted'
+        auroc:
+          class_path: torchmetrics.AUROC # ADD
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision # ADD
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro # Can be 'micro', 'macro', or 'weighted'
+      test:
+        f1:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro # Can be 'micro', 'macro', or 'weighted'
+        f1_micro:
+          class_path: torchmetrics.F1Score # ADD
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro # Can be 'micro', 'macro', or 'weighted'
+        auroc:
+          class_path: torchmetrics.AUROC # ADD
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision # ADD
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+    
+data:
+  class_path: marble.tasks.MTGTop50.datamodule.MTGTop50DataModule
+  init_args:
+    batch_size: 32
+    num_workers: 32
+
+    train:
+      class_path: marble.tasks.MTGTop50.datamodule.MTGTop50AudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGTop50.train.jsonl
+    val:
+      class_path: marble.tasks.MTGTop50.datamodule.MTGTop50AudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGTop50.val.jsonl
+    test:
+      class_path: marble.tasks.MTGTop50.datamodule.MTGTop50AudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGTop50.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 3
+    monitor: "val/auroc"

--- a/configs/probe.Auden.MergeGSHT.yaml
+++ b/configs/probe.Auden.MergeGSHT.yaml
@@ -1,0 +1,146 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MergeGSHT.Auden/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/weighted_score"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.HookTheoryKey.Auden"
+      save_dir: "./output/probe.MergeGSHT.Auden/"
+
+
+model:
+  class_path: marble.tasks.MergeGSHT.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Auden.model.Auden_Encoder
+      init_args:
+        pre_trained_folder: null
+        train_mode: freeze
+    emb_transforms:
+      - class_path: marble.modules.transforms.LayerSelector
+        init_args:
+          layers: [15]
+      - class_path: marble.modules.transforms.TimeAvgPool
+    
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 512
+          out_dim: 24 # 24 KEYS
+          hidden_layers: [512]
+          activation_fn: 
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+    
+data:
+  class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyDataModule
+  init_args:
+    batch_size: 16
+    num_workers: 16
+
+    train:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/MergeGSHT/MergeGSHT.train.jsonl
+        maj_minor_only: true # only use major and minor keys
+    val:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/MergeGSHT/MergeGSHT.val.jsonl
+        maj_minor_only: true # only use major and minor keys
+    test:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/GS/GS.test.jsonl
+        maj_minor_only: true
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/weighted_score"


### PR DESCRIPTION
## Summary
- Add Auden-based probe configs for GTZANGenre, GTZANBeatTracking, Chords1217, EMO, GS, HookTheoryKey, HookTheoryStructure, MergeGSHT, MTGGenre, MTGInstrument, MTGMood, and MTGTop50
- Use Auden encoder with 16 kHz sample rate, layer 15 embeddings, and 512-dim decoders across tasks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch' and 'numpy')*
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch)*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6892fb0bc4bc832483bb37e68067dad8